### PR TITLE
Modify subsystem of shim if needed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,7 @@
 on:
   push:
+    branches:
+      - trunk
   pull_request:
     branches:
       - trunk

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -785,6 +785,7 @@ name = "numin"
 version = "0.1.2"
 dependencies = [
  "clap",
+ "common",
  "reqwest",
  "thiserror",
  "widestring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,9 @@ strip = true
 panic = "abort"
 
 [dependencies]
-common = { path = "./common" }
+common = { path = "./common", default-features = false, features = [
+    "crt_functions",
+] }
 compiler_builtins_but_not_named_that = { version = "0.1", features = [
     "mem",
 ], package = "compiler_builtins" }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -3,6 +3,11 @@ edition = "2024"
 name = "common"
 version.workspace = true
 
+[features]
+crt_functions = []
+default = ["std"]
+std = []
+
 [dependencies]
 widestring = { version = "1.2.0", default-features = false, features = [
     "alloc",
@@ -10,6 +15,7 @@ widestring = { version = "1.2.0", default-features = false, features = [
 windows = { version = "0.61.1", default-features = false, features = [
     "Win32_Storage_FileSystem",
     "Win32_UI_Shell",
+    "Win32_UI_WindowsAndMessaging",
 ] }
 
 [build-dependencies]

--- a/common/build.rs
+++ b/common/build.rs
@@ -3,7 +3,7 @@ fn main() {
     build.file("interop/macros.c");
 
     #[cfg(feature = "crt_functions")]
-    build.include("interop/crt_fns.c");
+    build.file("interop/crt_fns.c");
 
     build.compile("interop");
     println!("cargo:rerun-if-changed=interop.c");

--- a/common/build.rs
+++ b/common/build.rs
@@ -1,9 +1,11 @@
 fn main() {
     let mut build = cc::Build::new();
     build.file("interop/macros.c");
+    println!("cargo:rerun-if-changed=interop/macros.c");
 
     #[cfg(feature = "crt_functions")]
     build.file("interop/crt_fns.c");
+    println!("cargo:rerun-if-changed=interop/crt_fns.c");
 
     build.compile("interop");
     println!("cargo:rerun-if-changed=interop.c");

--- a/common/build.rs
+++ b/common/build.rs
@@ -1,4 +1,10 @@
 fn main() {
-    cc::Build::new().file("interop.c").compile("interop");
+    let mut build = cc::Build::new();
+    build.file("interop/macros.c");
+
+    #[cfg(feature = "crt_functions")]
+    build.include("interop/crt_fns.c");
+
+    build.compile("interop");
     println!("cargo:rerun-if-changed=interop.c");
 }

--- a/common/interop/crt_fns.c
+++ b/common/interop/crt_fns.c
@@ -1,0 +1,6 @@
+#include <stddef.h>
+
+int _fltused = 0;
+
+extern __chkstk(size_t ptr) {
+}

--- a/common/interop/macros.c
+++ b/common/interop/macros.c
@@ -1,10 +1,5 @@
 #include <stddef.h>
 
-int _fltused = 0;
-
-extern __chkstk(size_t ptr) {
-}
-
 // The following is borrowed from minwindef.h
 typedef unsigned short WORD;
 

--- a/common/src/exe_type.rs
+++ b/common/src/exe_type.rs
@@ -8,7 +8,7 @@ pub struct ExeType {
     loword: u16,
 }
 
-impl std::fmt::Debug for ExeType {
+impl core::fmt::Debug for ExeType {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         fn format_bytes(bytes: &[u8]) -> String {
             bytes.iter().map(|byte| char::from(*byte)).collect()

--- a/common/src/exe_type.rs
+++ b/common/src/exe_type.rs
@@ -7,6 +7,33 @@ pub struct ExeType {
     loword: u16,
 }
 
+impl std::fmt::Debug for ExeType {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        fn format_bytes(bytes: &[u8]) -> alloc::string::String {
+            bytes.iter().map(|byte| char::from(*byte)).collect()
+        }
+
+        let formatted_hiword = format_bytes(&self.hiword.to_le_bytes());
+        let formatted_loword = format_bytes(&self.loword.to_le_bytes());
+
+        let mut debug_struct = f.debug_struct("ExeType");
+
+        if self.hiword == 0 {
+            debug_struct.field("hiword", &None::<String>);
+        } else {
+            debug_struct.field("hiword", &formatted_hiword);
+        }
+
+        if self.loword == 0 {
+            debug_struct.field("loword", &None::<String>);
+        } else {
+            debug_struct.field("loword", &formatted_loword);
+        }
+
+        debug_struct.finish()
+    }
+}
+
 impl ExeType {
     pub fn from_path(path: impl AsRef<WideCStr>) -> Option<Self> {
         use windows::{

--- a/common/src/exe_type.rs
+++ b/common/src/exe_type.rs
@@ -1,3 +1,4 @@
+use alloc::string::String;
 use widestring::WideCStr;
 
 use crate::interop::{hiword, loword};
@@ -9,7 +10,7 @@ pub struct ExeType {
 
 impl std::fmt::Debug for ExeType {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        fn format_bytes(bytes: &[u8]) -> alloc::string::String {
+        fn format_bytes(bytes: &[u8]) -> String {
             bytes.iter().map(|byte| char::from(*byte)).collect()
         }
 

--- a/common/src/interop.rs
+++ b/common/src/interop.rs
@@ -1,5 +1,6 @@
 //! Both functions in this file are ported almost directly from the original <https://github.com/71/scoop-better-shimexe/blob/master/shim.c>
 
+#[cfg(feature = "crt_functions")]
 mod externfns {
     trait Float:
         Copy

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,5 +1,7 @@
 #![warn(clippy::all, clippy::pedantic)]
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 pub mod exe_type;
 pub mod interop;
+
+extern crate alloc;

--- a/numin/Cargo.toml
+++ b/numin/Cargo.toml
@@ -8,6 +8,7 @@ version = { workspace = true }
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
+common = { path = "../common" }
 thiserror = "2.0"
 widestring = "1.2"
 windows = { version = "0.61", features = [

--- a/numin/build.rs
+++ b/numin/build.rs
@@ -36,6 +36,10 @@ fn main() {
 
         println!("cargo:rerun-if-changed={}", path.display());
     } else {
+        if cfg!(not(debug_assertions)) {
+            println!("cargo::warning=Downloading latest build in release mode");
+        }
+
         let download_url = concat!(
             "https://github.com/winpax/miniature/releases/download/v",
             env!("CARGO_PKG_VERSION"),

--- a/numin/src/executable/shim.rs
+++ b/numin/src/executable/shim.rs
@@ -46,6 +46,7 @@ pub struct Shim {
 
 impl Shim {
     #[must_use]
+    /// Get the path to the shim executable.
     pub fn path(&self) -> &Path {
         &self.path
     }

--- a/numin/src/executable/shim.rs
+++ b/numin/src/executable/shim.rs
@@ -1,6 +1,6 @@
 //! Handles updating a shim executable that is saved locally on disk
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use widestring::WideCString;
 use windows::{
@@ -45,6 +45,11 @@ pub struct Shim {
 }
 
 impl Shim {
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
     /// Update the string table section of the executable with the given arguments.
     ///
     /// # Errors
@@ -52,7 +57,7 @@ impl Shim {
     /// See [`widestring::error::ContainsNul`] for more details.
     ///
     /// Internal Windows errors also may occur, see [`windows::core::Error`] for more details.
-    pub fn set_resource(self, args: ShimArgs) -> error::Result<()> {
+    pub fn set_resource(&self, args: ShimArgs) -> error::Result<()> {
         let c_path = WideCString::from_os_str(self.path.as_os_str())?.into_boxed_ucstr();
 
         let Ok(exe_handle) =

--- a/numin/src/lib.rs
+++ b/numin/src/lib.rs
@@ -11,6 +11,7 @@
 pub mod error;
 mod executable;
 pub(crate) mod interop;
+pub mod subsystem;
 mod table;
 
 pub use executable::*;

--- a/numin/src/main.rs
+++ b/numin/src/main.rs
@@ -8,9 +8,11 @@
 use std::path::PathBuf;
 
 use clap::Parser;
+use common::exe_type::ExeType;
 use numin::{Executable, error, shim::ShimArgs};
+use widestring::WideCString;
 
-#[derive(Debug, Parser)]
+#[derive(Debug, Clone, Parser)]
 struct Args {
     #[clap(help = "Name of the shim")]
     name: String,
@@ -43,7 +45,18 @@ fn main() -> error::Result<()> {
 
     let exe = Executable::default();
     let shim = exe.save(&dest_path)?;
-    shim.set_resource(args.into())?;
+    shim.set_resource(args.clone().into())?;
+
+    let wide_path = WideCString::from_os_str(args.target.as_os_str())?;
+    let exe_type = ExeType::from_path(&wide_path).expect("Failed to get the executable type");
+
+    dbg!(&exe_type);
+
+    if exe_type.is_windows() {
+        println!("Encoding GUI subsystem");
+        let subsystem = numin::subsystem::Subsystem::Windows;
+        subsystem.encode(dest_path)?;
+    }
 
     Ok(())
 }

--- a/numin/src/main.rs
+++ b/numin/src/main.rs
@@ -26,6 +26,9 @@ struct Args {
         value_name = "ARGS"
     )]
     shim_args: Vec<String>,
+
+    #[clap(help = "Do not set the subsystem of the shim", long, short)]
+    no_subsystem: bool,
 }
 
 impl From<Args> for ShimArgs {
@@ -50,12 +53,15 @@ fn main() -> error::Result<()> {
     let wide_path = WideCString::from_os_str(args.target.as_os_str())?;
     let exe_type = ExeType::from_path(&wide_path).expect("Failed to get the executable type");
 
-    dbg!(&exe_type);
-
     if exe_type.is_windows() {
-        println!("Encoding GUI subsystem");
-        let subsystem = numin::subsystem::Subsystem::Windows;
-        subsystem.encode(dest_path)?;
+        println!("Target executable is a GUI application");
+        if args.no_subsystem {
+            println!("NOT setting the subsystem to Windows GUI, as requested");
+        } else {
+            println!("Setting the subsystem to Windows GUI");
+            let subsystem = numin::subsystem::Subsystem::Windows;
+            subsystem.encode(dest_path)?;
+        }
     }
 
     Ok(())

--- a/numin/src/subsystem.rs
+++ b/numin/src/subsystem.rs
@@ -1,3 +1,5 @@
+//! Subsystems for Windows executables
+
 use std::{
     io::{Read, Seek, Write},
     path::PathBuf,
@@ -12,12 +14,19 @@ pub enum Subsystem {
 
 impl Subsystem {
     #[must_use]
+    /// Get the subsystem code for the given subsystem.
     pub const fn code(self) -> u16 {
         match self {
             Subsystem::Windows => 2,
         }
     }
 
+    /// Encode the given subsystem into the executable at the given path.
+    ///
+    /// # Errors
+    /// Seeking to particular offsets in the file may fail if the file is not a valid PE executable.
+    /// Writing to the file may fail.
+    /// See [`std::io::Error`] for more details.
     pub fn encode(self, path: PathBuf) -> std::io::Result<()> {
         let mut file = std::fs::OpenOptions::new()
             .read(true)

--- a/numin/src/subsystem.rs
+++ b/numin/src/subsystem.rs
@@ -1,0 +1,45 @@
+use std::{
+    io::{Read, Seek, Write},
+    path::PathBuf,
+};
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+/// Subsystems for Windows executables
+pub enum Subsystem {
+    /// Windows GUI subsystem
+    Windows,
+}
+
+impl Subsystem {
+    #[must_use]
+    pub const fn code(self) -> u16 {
+        match self {
+            Subsystem::Windows => 2,
+        }
+    }
+
+    pub fn encode(self, path: PathBuf) -> std::io::Result<()> {
+        let mut file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(path)?;
+
+        file.seek(std::io::SeekFrom::Start(0x3C))?;
+        let pe_offset = {
+            let mut buf = [0; 4];
+            file.read_exact(&mut buf)?;
+            u32::from_le_bytes(buf)
+        };
+
+        let file_header_offset = file.seek(std::io::SeekFrom::Start(u64::from(pe_offset)))?;
+
+        // Not sure the point of this call
+        // reader.seek(std::io::SeekFrom::Current(18))?;
+
+        file.seek(std::io::SeekFrom::Start(file_header_offset + 0x5C))?;
+
+        file.write_all(&self.code().to_le_bytes())?;
+
+        Ok(())
+    }
+}

--- a/numin/src/subsystem.rs
+++ b/numin/src/subsystem.rs
@@ -28,12 +28,15 @@ impl Subsystem {
     /// Writing to the file may fail.
     /// See [`std::io::Error`] for more details.
     pub fn encode(self, path: PathBuf) -> std::io::Result<()> {
+        const PE_HEADER_OFFSET_LOCATION: u64 = 0x3C;
+        const HEADER_SUBSYSTEM_OFFSET: u64 = 0x5C;
+
         let mut file = std::fs::OpenOptions::new()
             .read(true)
             .write(true)
             .open(path)?;
 
-        file.seek(std::io::SeekFrom::Start(0x3C))?;
+        file.seek(std::io::SeekFrom::Start(PE_HEADER_OFFSET_LOCATION))?;
         let pe_offset = {
             let mut buf = [0; 4];
             file.read_exact(&mut buf)?;
@@ -42,10 +45,9 @@ impl Subsystem {
 
         let file_header_offset = file.seek(std::io::SeekFrom::Start(u64::from(pe_offset)))?;
 
-        // Not sure the point of this call
-        // reader.seek(std::io::SeekFrom::Current(18))?;
-
-        file.seek(std::io::SeekFrom::Start(file_header_offset + 0x5C))?;
+        file.seek(std::io::SeekFrom::Start(
+            file_header_offset + HEADER_SUBSYSTEM_OFFSET,
+        ))?;
 
         file.write_all(&self.code().to_le_bytes())?;
 


### PR DESCRIPTION
Closes #14 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new command-line flag that lets users decide whether to apply Windows subsystem settings to executables.
  - Added functionality to encode subsystem information, ensuring Windows GUI applications are correctly flagged.
  - Added a new public method to access the path in the `Shim` struct.
  - Introduced a new `Subsystem` module for managing Windows executable subsystems.
  - Enhanced the `Args` struct to include a new boolean field for subsystem settings.
  - Added a new feature configuration for the `common` package, enabling specific functionalities.

- **Chores**
  - Enhanced dependency management and build configurations for better modularity and optional feature support.
  - Streamlined internal resource handling and debugging outputs to improve overall stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->