### PR TITLE
fixed builds and moved creation into seperate command

### DIFF
--- a/numin/build.rs
+++ b/numin/build.rs
@@ -40,8 +40,10 @@ fn main() {
             println!("cargo::warning=Downloading latest build in release mode");
         }
 
+        let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH")
+            .unwrap_or_else(|_| std::env::consts::ARCH.to_string());
         let arch = {
-            match std::env::consts::ARCH {
+            match target_arch.as_str() {
                 "x86" => "i686",
                 "x86_64" => "x86_64",
                 "aarch64" => "aarch64",

--- a/numin/build.rs
+++ b/numin/build.rs
@@ -40,15 +40,29 @@ fn main() {
             println!("cargo::warning=Downloading latest build in release mode");
         }
 
-        let download_url = concat!(
-            "https://github.com/winpax/miniature/releases/download/v",
+        let arch = {
+            match std::env::consts::ARCH {
+                "x86" => "i686",
+                "x86_64" => "x86_64",
+                "aarch64" => "aarch64",
+                _ => {
+                    println!("cargo::error=Unsupported architecture");
+                    return;
+                }
+            }
+        };
+
+        let bin_name = format!("miniature-{arch}.exe");
+
+        let download_url = format!(
+            "https://github.com/winpax/miniature/releases/download/v{}/{}",
             env!("CARGO_PKG_VERSION"),
-            "/miniature.exe"
+            bin_name
         );
 
         let resp = handle_error(reqwest::blocking::get(download_url));
         if !resp.status().is_success() {
-            println!("cargo::error=Failed to download miniature.exe");
+            println!("cargo::error=Failed to download {}", bin_name);
             println!("cargo::error={}", resp.status());
         } else {
             let binary_data = handle_error(resp.bytes());

--- a/numin/src/commands.rs
+++ b/numin/src/commands.rs
@@ -1,0 +1,7 @@
+mod create;
+
+#[derive(Debug, Clone, clap::Subcommand)]
+pub enum Commands {
+    /// Create a new miniature shim
+    Create(create::Args),
+}

--- a/numin/src/commands/create.rs
+++ b/numin/src/commands/create.rs
@@ -1,0 +1,62 @@
+use std::path::PathBuf;
+
+use common::exe_type::ExeType;
+use numin::{Executable, shim::ShimArgs};
+use widestring::WideCString;
+
+use crate::error;
+
+#[derive(Debug, Clone, clap::Args)]
+pub struct Args {
+    #[clap(help = "Name of the shim")]
+    name: String,
+
+    #[clap(help = "Path to the executable to shim")]
+    target: PathBuf,
+
+    #[allow(clippy::struct_field_names)]
+    #[clap(
+        help = "Arguments to pass to the executable from the shim",
+        value_name = "ARGS"
+    )]
+    shim_args: Vec<String>,
+
+    #[clap(help = "Do not set the subsystem of the shim", long, short)]
+    no_subsystem: bool,
+}
+
+impl From<Args> for ShimArgs {
+    fn from(args: Args) -> Self {
+        ShimArgs::new(args.target, args.shim_args)
+    }
+}
+
+impl Args {
+    pub fn run(&self) -> error::Result<()> {
+        if matches!(PathBuf::from(&self.name).try_exists(), Ok(true)) {
+            Err(error::Error::AlreadyExists)?;
+        }
+
+        let dest_path = PathBuf::from(&self.name).with_extension("exe");
+
+        let exe = Executable::default();
+        let shim = exe.save(&dest_path)?;
+        shim.set_resource(self.clone().into())?;
+
+        let wide_path = WideCString::from_os_str(self.target.as_os_str())?;
+        let exe_type = ExeType::from_path(&wide_path).expect("Failed to get the executable type");
+
+        if exe_type.is_windows() {
+            println!("Target executable is a GUI application");
+            if self.no_subsystem {
+                println!("NOT setting the subsystem to Windows GUI, as requested");
+            } else {
+                println!("Setting the subsystem to Windows GUI");
+                let subsystem = numin::subsystem::Subsystem::Windows;
+                subsystem.encode(dest_path)?;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/numin/src/commands/create.rs
+++ b/numin/src/commands/create.rs
@@ -33,11 +33,11 @@ impl From<Args> for ShimArgs {
 
 impl Args {
     pub fn run(&self) -> error::Result<()> {
-        if matches!(PathBuf::from(&self.name).try_exists(), Ok(true)) {
+        let dest_path = PathBuf::from(&self.name).with_extension("exe");
+
+        if matches!(dest_path.try_exists(), Ok(true)) {
             Err(error::Error::AlreadyExists)?;
         }
-
-        let dest_path = PathBuf::from(&self.name).with_extension("exe");
 
         let exe = Executable::default();
         let shim = exe.save(&dest_path)?;

--- a/numin/src/main.rs
+++ b/numin/src/main.rs
@@ -5,63 +5,24 @@
     missing_copy_implementations
 )]
 
-use std::path::PathBuf;
+mod commands;
 
 use clap::Parser;
-use common::exe_type::ExeType;
-use numin::{Executable, error, shim::ShimArgs};
-use widestring::WideCString;
+use numin::error;
+
+use crate::commands::Commands;
 
 #[derive(Debug, Clone, Parser)]
 struct Args {
-    #[clap(help = "Name of the shim")]
-    name: String,
-
-    #[clap(help = "Path to the executable to shim")]
-    target: PathBuf,
-
-    #[allow(clippy::struct_field_names)]
-    #[clap(
-        help = "Arguments to pass to the executable from the shim",
-        value_name = "ARGS"
-    )]
-    shim_args: Vec<String>,
-
-    #[clap(help = "Do not set the subsystem of the shim", long, short)]
-    no_subsystem: bool,
-}
-
-impl From<Args> for ShimArgs {
-    fn from(args: Args) -> Self {
-        ShimArgs::new(args.target, args.shim_args)
-    }
+    #[clap(subcommand)]
+    command: Commands,
 }
 
 fn main() -> error::Result<()> {
     let args = Args::parse();
 
-    if matches!(PathBuf::from(&args.name).try_exists(), Ok(true)) {
-        Err(error::Error::AlreadyExists)?;
-    }
-
-    let dest_path = PathBuf::from(&args.name).with_extension("exe");
-
-    let exe = Executable::default();
-    let shim = exe.save(&dest_path)?;
-    shim.set_resource(args.clone().into())?;
-
-    let wide_path = WideCString::from_os_str(args.target.as_os_str())?;
-    let exe_type = ExeType::from_path(&wide_path).expect("Failed to get the executable type");
-
-    if exe_type.is_windows() {
-        println!("Target executable is a GUI application");
-        if args.no_subsystem {
-            println!("NOT setting the subsystem to Windows GUI, as requested");
-        } else {
-            println!("Setting the subsystem to Windows GUI");
-            let subsystem = numin::subsystem::Subsystem::Windows;
-            subsystem.encode(dest_path)?;
-        }
+    match args.command {
+        Commands::Create(args) => args.run()?,
     }
 
     Ok(())


### PR DESCRIPTION
TODO:
- [ ] Update CHANGELOG
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a "create" CLI subcommand to generate a new shim (name, target, optional args, and flag to skip Windows GUI subsystem).
  - Improved user-facing status and error messages during shim creation.

- Refactor
  - Reorganized the CLI into a subcommand-based structure with centralized command dispatch.

- Chores
  - Build now detects CPU architecture to download the matching binary and reports the actual binary name on failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->